### PR TITLE
Optimize regular expressions

### DIFF
--- a/userscripts/yt-remove-tracking.user.js
+++ b/userscripts/yt-remove-tracking.user.js
@@ -16,10 +16,10 @@
     function removeTrackingParameters(input) {
         if (input && input.value) {
             let newValue = input.value
-                .replace(/(\&|\?)si=[^&]+/, '')
-                .replace(/(\&|\?)pp=[^&]+/, '')
+                .replace(/(?:&|\?)si=[^&]+/, '')
+                .replace(/(?:&|\?)pp=[^&]+/, '')
                 .replace(/^([^?]+)&/, '$1?')
-                .replace(/(youtube\.com\/shorts\/|www\.youtube\.com\/watch\?v=|music\.youtube\.com\/watch\?v=)([a-zA-Z0-9_-]+)/, 'youtu.be/$2');
+                .replace(/(?:youtube\.com\/shorts\/|www\.youtube\.com\/watch\?v=|music\.youtube\.com\/watch\?v=)([a-zA-Z0-9_-]+)/, 'youtu.be/$1');
 
             if (input.value !== newValue) {
                 input.value = newValue;
@@ -58,7 +58,7 @@
             if (element.tagName.toLowerCase() === 'input') {
                 removeTrackingParameters(element);
             } else if (element.tagName.toLowerCase() === 'a' && /\/watch\?v=/.test(element.href)) {
-                element.href = element.href.replace(/(\&|\?)si=[^&]+/, '').replace(/(\&|\?)pp=[^&]+/, '');
+                element.href = element.href.replace(/(?:&|\?)si=[^&]+/, '').replace(/(?:&|\?)pp=[^&]+/, '');
             }
         });
     }, 50);


### PR DESCRIPTION
In the Mozilla developer documentation, it is mentioned that using capturing groups has a slight performance penalty.
I changed all the groups whose capture is not used into non-capturing groups.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences#types

I'll take this opportunity to report that the script seems to cause performance problems, at least on my end.